### PR TITLE
Enable pcsd_mode for RHEL >= 6.6

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -34,8 +34,12 @@ class pacemaker::params {
     'redhat': {
       if $::operatingsystemrelease =~ /^6\..*$/ {
         $package_list = ['pacemaker','pcs','fence-agents','cman']
-        # TODO in el6.6, $pcsd_mode should be true
-        $pcsd_mode = false
+        # in el6.6, $pcsd_mode should be true
+        if $::os['release']['minor'] >= 6 {
+          $pcsd_mode = true
+        } else {
+          $pcsd_mode = false
+        }
         $services_manager = 'lsb'
       } else {
         $package_list = ['pacemaker','pcs','fence-agents-all','pacemaker-libs']


### PR DESCRIPTION
As mentioned at https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Configuring_the_Red_Hat_High_Availability_Add-On_with_Pacemaker/ch-overview-HAAR.html from update 6 also EL6 systems are using `pcs` as in EL7.