### PR TITLE
Update default.rb

### DIFF
--- a/lib/puppet/provider/pcmk_constraint/default.rb
+++ b/lib/puppet/provider/pcmk_constraint/default.rb
@@ -11,7 +11,7 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
             cmd = 'constraint location add ' + resource_name + ' '  + resource_resource + ' ' + @resource[:location] + ' ' + @resource[:score]
         when :colocation
             resource_location = @resource[:location].gsub(':', '.')
-            if @resource[:master_slave]
+            if @resource[:master_slave] == :true
               cmd = 'constraint colocation add ' + resource_resource + ' with master ' + resource_location + ' ' + @resource[:score]
             else 
               cmd = 'constraint colocation add ' + resource_resource + ' with ' + resource_location + ' ' + @resource[:score]
@@ -50,7 +50,7 @@ Puppet::Type.type(:pcmk_constraint).provide(:default) do
             when :location
                 return true if line.include? resource_name
             when :colocation
-                if @resource[:master_slave]
+                if @resource[:master_slave] == :true
                   return true if line.include? resource_resource + ' with ' + resource_location and line.include? "with-rsc-role:Master"
                 else
                   return true if line.include? resource_resource + ' with ' + resource_location


### PR DESCRIPTION
Since the value of @resource[:master_slave] is either :true or :false, and symbols in Ruby are always truthy, this needs to be compared explicitly with the symbol :true.

This is actually the same fix as in the following pull request:
https://github.com/redhat-openstack/puppet-pacemaker/pull/66

This was closed, because the project was moved from redhat-openstack to openstack, with the suggestion to resubmit the fix to the new location. However this was never done by the original author of the fix.

Hence I am submitting this fix myself.
