### PR TITLE
Let the system PATH determine which `systemctl` binary to call

### DIFF
--- a/lib/facter/pcmk_is_remote.rb
+++ b/lib/facter/pcmk_is_remote.rb
@@ -2,7 +2,7 @@ require 'facter'
 
 Facter.add('pcmk_is_remote') do
   setcode do
-    systemd_pcmk_remote = `/usr/bin/systemctl is-active pacemaker_remote`
+    systemd_pcmk_remote = `systemctl is-active pacemaker_remote`
     systemd_pcmk_remote.downcase.chomp == 'active'
   end
 end


### PR DESCRIPTION
Some systems have the `systemctl` binary in locations other than `/usr/bin`,
e.g. Ubuntu and Debian (where it exists as `/bin/systemctl`). Instead of forcing
an absolute path we can just use the first from `$PATH`.