### PR TITLE
Stable/0.6.x

### DIFF
--- a/.gitreview
+++ b/.gitreview
@@ -2,3 +2,4 @@
 host=review.openstack.org
 port=29418
 project=openstack/puppet-pacemaker.git
+defaultbranch=stable/0.6.x

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,0 +1,5 @@
+- project:
+    name: openstack/puppet-pacemaker
+    templates:
+      - puppet-openstack-check-jobs
+      - puppet-openstack-module-unit-jobs

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,8 +1,18 @@
 - project:
     name: openstack/puppet-pacemaker
-    templates:
-      - puppet-openstack-check-jobs
-      - puppet-openstack-module-unit-jobs
-    check-tripleo:
+    check:
       jobs:
-        - tripleo-ci-centos-7-ovb-ha-oooq
+        - puppet-openstack-lint:
+            override-checkout: stable/ocata
+        - puppet-openstack-syntax-4:
+            override-checkout: stable/ocata
+        - puppet-openstack-unit-4.8-centos-7:
+            override-checkout: stable/ocata
+    gate:
+      jobs:
+        - puppet-openstack-lint:
+            override-checkout: stable/ocata
+        - puppet-openstack-syntax-4:
+            override-checkout: stable/ocata
+        - puppet-openstack-unit-4.8-centos-7:
+            override-checkout: stable/ocata

--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -3,3 +3,6 @@
     templates:
       - puppet-openstack-check-jobs
       - puppet-openstack-module-unit-jobs
+    check-tripleo:
+      jobs:
+        - tripleo-ci-centos-7-ovb-ha-oooq

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 group :test do
+  gem 'jwt', '~> 1.5.6',                                            :require => false
   gem 'nokogiri', '~> 1.6.0',                                       :require => false
   gem 'rake',                                                       :require => false
   gem 'rspec-puppet',                                               :require => false
@@ -26,7 +27,7 @@ group :test do
   gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
   gem 'puppet-lint-unquoted_string-check',                          :require => false
   gem 'puppet-lint-variable_contains_upcase',                       :require => false
-  gem 'rubocop',                                                    :require => false
+  gem 'rubocop', '~> 0.50.0',                                       :require => false
   gem 'unicode-display_width',                                      :require => false
   gem 'puppetlabs_spec_helper',                                     :require => false
 end

--- a/lib/pacemaker/pcs/pcsd_auth.rb
+++ b/lib/pacemaker/pcs/pcsd_auth.rb
@@ -29,9 +29,9 @@ module Pacemaker
       inside_debug_block = false
       result = []
       output.split("\n").each do |line|
-        inside_debug_block = false if line == '--Debug Output End--'
+        inside_debug_block = false if line =~ /--Debug (Output|Stdout) End--/
         result << line if inside_debug_block
-        inside_debug_block = true if line == '--Debug Output Start--'
+        inside_debug_block = true if line =~ /--Debug (Output|Stdout) Start--/
       end
       return unless result.any?
       result.join("\n")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 envlist = releasenotes
 
 [testenv]
-install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt} {opts} {packages}
+install_command = pip install -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/0.6.x} {opts} {packages}
 
 [testenv:releasenotes]
 deps = -rtest-requirements.txt


### PR DESCRIPTION

[fence_ipmilan.txt](https://github.com/openstack/puppet-pacemaker/files/2206121/fence_ipmilan.txt)

Updated manifests/stonith/fence_ipmilan.pp to accept a different fence-agent-ipmilan package name as in Ubuntu all the agents are available via a single package: fence-agents
Probably this could be extended to all the fencing agents.