### PR TITLE
Fix displaying node name via crm_node -n right after pcs cluster auth

### DIFF
--- a/lib/puppet/provider/pacemaker_pcsd_auth/pacemaker_pcs.rb
+++ b/lib/puppet/provider/pacemaker_pcsd_auth/pacemaker_pcs.rb
@@ -65,7 +65,6 @@ Puppet::Type.type(:pacemaker_pcsd_auth).provide(:pcs, parent: Puppet::Provider::
       success = success_node_statuses.include? status
       prefix = success ? 'OK  ' : 'FAIL'
       message += "#{prefix} #{node} (#{status})"
-      message += ' <- this node' if node_name == node
       message += "\n"
     end
     message += 'Cluster auth status debug end'


### PR DESCRIPTION
Right after updating to pacemaker 1.1.19-8.el7_6.4 we noticed that puppet could not really create the cluster unless we seeded proper corosync configuration (which is done by pcs cluster setup right after pcs cluster auth is done).

We ended up with having this error all the time:

` puppet-agent[23616]: (/Stage[main]/Pacemaker::New::Setup::Pcsd/Pacemaker_pcsd_auth[setup]) Could not evaluate: Execution of '/sbin/crm_node -n' returned 107: error: Could not connect to cluster (is it running?)
`

This pull request removes calling crm_node -n via printing a debug message whether node was authenticated right after pcs cluster auth which seems to be (in my view) not a proper way of doing it. crm_node -n requires working cluster to be running, which is done after pcs cluster setup step.

This is the way I fixed it on my side, can you guys verify if this should be done in any other way or if this patch would break anything ?

~asm 