### PR TITLE
fix did_stonith_location_exist check

### DIFF
--- a/lib/puppet/provider/pcmk_stonith/default.rb
+++ b/lib/puppet/provider/pcmk_stonith/default.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:pcmk_stonith).provide(:default) do
     # because we do not know why we're being created (if for both or
     # only for one)
     did_stonith_resource_exist = @resources_state[@resource[:name]] == PCMK_NOCHANGENEEDED
-    did_stonith_location_exist = @locations_state[@resource[:name]] == PCMK_NOCHANGENEEDED
+    did_stonith_location_exist = @locations_state[@resource[:name]]
 
     Puppet.debug("Create: stonith exists #{did_stonith_resource_exist} location exists #{did_stonith_location_exist}")
 
@@ -93,7 +93,7 @@ Puppet::Type.type(:pcmk_stonith).provide(:default) do
     @locations_state[@resource[:name]] = stonith_location_exists?
     @resources_state[@resource[:name]] = stonith_resource_exists?
     did_stonith_resource_exist = @resources_state[@resource[:name]] == PCMK_NOCHANGENEEDED
-    did_stonith_location_exist = @locations_state[@resource[:name]] == PCMK_NOCHANGENEEDED
+    did_stonith_location_exist = @locations_state[@resource[:name]]
 
     Puppet.debug("Exists: stonith resource exists #{did_stonith_resource_exist} location exists #{did_stonith_location_exist}")
     if did_stonith_resource_exist and did_stonith_location_exist


### PR DESCRIPTION
do not queue unnecessary corrective changes in puppet, as
stonith_location_exists returnes boolean

stonith_location_exists? only returns a boolean value (as opposed to stonith_resource_exists? which returns PCMK_NOCHANGENEEDED). This would trigger unnecessary corrective changes in puppet, as it always tries to add an already existing location-constraint.